### PR TITLE
feat : get api-resources data of the selected context

### DIFF
--- a/src/app/backend/pkg/lang/functions.go
+++ b/src/app/backend/pkg/lang/functions.go
@@ -28,3 +28,12 @@ func DivideRound(a int64, b int64, decimal int) float64 {
 	}
 
 }
+
+func ArrayContains(arr []string, str string) bool {
+	for _, s := range arr {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}

--- a/src/app/frontend/plugins/mixin-common-methods.js
+++ b/src/app/frontend/plugins/mixin-common-methods.js
@@ -145,17 +145,22 @@ Vue.mixin({
 
       return Math.floor(seconds) + " seconds";
     },
-    // namespace 리스트 조회
+    // Get currentContext's namespaces
     namespaces(_) {
       if (_) this.$store.commit("setNamespaces", _);
       else return this.$store.getters["getNamespaces"];
     },
-    // context (cluster) 리스트 조회
+    // Get contexts
     contexts(_) {
       if (_) this.$store.commit("setContexts", _);
       else return this.$store.getters["getContexts"];
     },
-    // 현재 선택된 context (cluster) 조회
+    // Get currentContext's resources
+    resources(_) {
+      if (_) this.$store.commit("setResources", _);
+      else return this.$store.getters["getResources"];
+    },
+    // Get a currentContext
     currentContext(_) {
       if (_) this.$store.commit("setCurrentContext", _);
       else return this.$store.getters["getCurrentContext"];

--- a/src/app/frontend/store/index.js
+++ b/src/app/frontend/store/index.js
@@ -1,7 +1,8 @@
 export const state = () => ({
-  currentContext: "", // 선택된 cluster context
-  contexts: [], // context 리스트
-  namespaces: [], // 현재 context 의 namespace 리스트
+  currentContext: "", // currentContext
+  contexts: [], // context list
+  namespaces: [], // currentContext namespace 리스트
+  resources: [], // currentContext resource 리스트
 });
 export const mutations = {
   setCurrentContext(state, ctx) {
@@ -13,6 +14,9 @@ export const mutations = {
   setNamespaces(state, namespaces) {
     state.namespaces = namespaces;
   },
+  setResources(state, resources) {
+    state.resources = resources;
+  },
 };
 export const getters = {
   getCurrentContext(state) {
@@ -23,5 +27,8 @@ export const getters = {
   },
   getNamespaces(state) {
     return state.namespaces;
+  },
+  getResources(state) {
+    return state.resources;
   },
 };


### PR DESCRIPTION
* get api-resources data of the selected context
* http://{{HOST}}:{{BACKEND_PORT}}/api/clusters?ctx=cluster
```
{
    "contexts": [
        "apps-05",
        "apps-06"
    ],
    "currentContext": {
        "name": "apps-05",
        "namespaces": [
            "acornsoft-dashboard",
            "default",
            "kube-public",
            "kube-system",
            "sock-shop"
        ],
        "resources": {
            "adapters": {
                "groupVersion": "config.istio.io/v1alpha2",
                "kind": "adapter",
                "name": "adapters",
                "namespaced": true
            },
            "alertmanagers": {
                "groupVersion": "monitoring.coreos.com/v1",
                "kind": "Alertmanager",
                "name": "alertmanagers",
                "namespaced": true
            },
     .....        
```