### PR TITLE
refactor: view page

### DIFF
--- a/src/app/frontend/assets/css/app.css
+++ b/src/app/frontend/assets/css/app.css
@@ -2,11 +2,6 @@
 .content a.nav-link.active {border-bottom: 3px solid #007bff; color: #007bff; margin: 0rem .3rem}
 .content a.nav-link {padding: .3rem .3rem; color:#aaa}
 
-/* json2html */
-.jsontree_child-nodes {list-style: none;}
-.jsontree_child-nodes {margin-left: 0}
-.jsontree_tree ul {padding-inline-start: 20px;} 
-
 /* default layout */
 .main-sidebar, .main-sidebar::before { width: 17rem;}
 .sidebar-collapse .main-sidebar, .sidebar-collapse .main-sidebar::before { margin-left: -17rem; }

--- a/src/app/frontend/components/json-tree/jsonTree.css
+++ b/src/app/frontend/components/json-tree/jsonTree.css
@@ -13,8 +13,8 @@
 
 /* Styles for the container of the tree (e.g. fonts, margins etc.) */
 .jsontree_tree {
-    margin-left: 1rem;
-	padding-left: 0;
+    margin: 0;
+	padding: 0;
 	font-size: 0.875rem !important;
 	list-style: none;
 }
@@ -25,6 +25,7 @@
     margin-left: 1.5rem; 
 	padding-left: 0; 
     line-height: 1.85;
+	list-style: none;
 }
 .jsontree_node_expanded > .jsontree_value-wrapper > .jsontree_value > .jsontree_child-nodes {
     display: block;

--- a/src/app/frontend/components/jsontree.vue
+++ b/src/app/frontend/components/jsontree.vue
@@ -1,5 +1,5 @@
 <template>
-<div id="wrapEditor"></div>
+<div></div>
 </template>
 <script>
 import "@/components/json-tree/jsonTree.css";
@@ -10,7 +10,8 @@ export default {
 	props:["value"],
 	data () {
 		return {
-			localValue: this.value
+			localValue: this.value,
+			object: null
 		}
 	},
 	mounted(){
@@ -19,8 +20,13 @@ export default {
 		value(newVal) {
 			try {
 				if(this.localValue != newVal) {
-					jsonTree.create(newVal, this.$el).expand();
+					if(this.object) {
+						this.object.loadData(newVal);
+					} else {
+						this.object = jsonTree.create(newVal, this.$el);
+					}
 					this.localValue = newVal;
+					this.object.expand();
 				}
 			} catch (ex) {
 				console.error(ex.message);

--- a/src/app/frontend/pages/create.vue
+++ b/src/app/frontend/pages/create.vue
@@ -11,7 +11,7 @@
 					<h1 class="m-0 text-dark"><span class="badge badge-info mr-2">{{ badge }}</span>Create {{ crd }}</h1>
 				</div>
 				<div class="col-sm-2 text-right">
-					<b-button variant="primary" size="sm"  @click="onApply">Apply</b-button>
+					<b-button variant="primary" size="sm"  @click="onCreate">Create</b-button>
 					<b-button variant="secondary" size="sm" @click="$router.go(-1)">Back</b-button>
 				</div>
 			</div>
@@ -23,7 +23,7 @@
 			<div class="col-md-12">
 				<div class="card">
 					<div class="card-header"></div>
-					<c-aceeditor class="card-body" v-model="raw" v-on:error="onError" style="min-height: calc(100vh - 210px - 60px)"></c-aceeditor>
+					<c-aceeditor class="card-body" v-model="raw" v-on:error="onError" style="min-height: calc(100vh - 270px)"></c-aceeditor>
 				</div>
 			</div>
 		</div>
@@ -70,12 +70,13 @@ export default {
 		this.$nuxt.$off('navbar-context-selected')
 	},
 	methods: {
-		onApply() {
+		onCreate() {
 			axios.post(`${this.backendUrl()}/raw/clusters/${this.currentContext()}`, this.raw)
 				.then( resp => {
 					this.origin = Object.assign({}, resp.data);
 					this.raw = resp.data;
 					this.toast("Apply OK", "info");
+					this.$router.go(-1);
 				})
 				.catch(e => { this.msghttp(e);});
 		},

--- a/src/app/frontend/pages/view.vue
+++ b/src/app/frontend/pages/view.vue
@@ -1,150 +1,129 @@
 <template>
-<!-- content-wrapper -->
-<div class="content-wrapper">
-
-	<!-- Content Header (Page header) -->
-	<div class="content-header">
-		<div class="container-fluid">
-			<c-navigator :group="group"></c-navigator>
-			<div class="row mb-2">
-				<div class="col-sm-10">
-					<b-overlay :show="deleteOverlay.visible" rounded="sm">
-					<h1 class="m-0 text-dark"><span class="badge badge-info mr-2">{{ badge }}</span>{{ crd }}<small class="text-muted ml-2">/ {{ name }}<small><i class="fas fa-trash ml-2" @click="deleteOverlay.visible = true"></i></small></small></h1>
-					<template #overlay>
-						<div v-if="deleteOverlay.processing" class="text-center">
-							<b-spinner small class="mr-2" label="please wait"></b-spinner><span>Watching DELETE status...</span>
+<section class="content border-primary border-left">
+	<div class="card card-primary m-0">
+		<!-- card-header -->
+		<div class="card-header pt-2 pb-2">
+			<h3 class="card-title">{{ name }}</h3>
+			<div class="card-tools">
+				<button type="button" class="btn btn-tool" @click="onSync()"><i class="fas fa-sync-alt"></i></button>
+				<button type="button" class="btn btn-tool" @click="isYaml=true"><i class="fas fa-edit"></i></button>
+				<button type="button" class="btn btn-tool" @click="deleteOverlay.visible = true"><i class="fas fa-trash"></i></button>
+				<button type="button" class="btn btn-tool" @click="$emit('close')"><i class="fas fa-times"></i></button>
+			</div>
+		</div>
+		<b-overlay :show="deleteOverlay.visible" rounded="sm" no-center>
+		<!-- summary -->
+		<div v-show="!isYaml" class="card-body p-2">
+			<div class="row">
+				<div class="col-md-12">
+					<div class="card card-secondary card-outline">
+						<div class="card-header p-2"><h3 class="card-title text-md">Meta data</h3></div>
+						<div class="card-body p-2">
+							<dl class="row mb-0">
+								<dt class="col-sm-2">Annotations</dt>
+								<dd class="col-sm-10 text-truncate">
+									<ul class="list-unstyled mb-0">
+										<li v-for="(value, name) in raw.metadata.annotations" v-bind:key="name"><span class="badge badge-secondary font-weight-light text-sm mb-1">{{ name }}:{{ value }}</span></li>
+									</ul>
+								</dd>
+								<dt class="col-sm-2">Labels</dt>
+								<dd class="col-sm-10">
+									<ul class="list-unstyled mb-0">
+										<li v-for="(value, name) in raw.metadata.labels" v-bind:key="name"><span class="badge badge-secondary font-weight-light text-sm mb-1">{{ name }}:{{ value }}</span></li>
+									</ul>
+								</dd>
+								<dt class="col-sm-2">Create at</dt><dd class="col-sm-10">{{ raw.metadata.creationTimestamp }}</dd>
+								<dt class="col-sm-2">UID</dt><dd class="col-sm-10">{{ raw.metadata.uid }}</dd>
+							</dl>
 						</div>
-						<div v-else class="text-center">
-							<p>Are you sure DELETE it?</p>
-							<div class="text-center">
-								<b-button variant="outline-danger" size="sm" class="mr-1" @click="deleteOverlay.visible = false">Cancel</b-button>
-								<b-button variant="outline-success" size="sm" @click="onDelete">OK</b-button>
-							</div>
-						</div>
-					</template>
-					</b-overlay>
+					</div>
 				</div>
-				<div class="col-sm-2 text-right">
-					<b-button variant="secondary" size="sm" @click="$router.go(-1)">Cancel</b-button>
+			</div>
+			<div class="row" v-if="crd != 'Storage Class'">
+				<div class="col-md-12">
+					<div class="card card-secondary card-outline m-0">
+						<div class="card-header p-2">
+							<h3 class="card-title text-md" v-if="crd=='Config Map' || crd=='Secret'">Data</h3>
+							<h3 class="card-title text-md" v-else-if="crd=='Service Account'">Secrets</h3>
+							<h3 class="card-title text-md" v-else-if="crd=='Role' || crd=='Cluster Role'">Rules</h3>
+							<h3 class="card-title text-md" v-else-if="crd=='Role Binding' || crd=='Cluster Role Binding'">Subjects,RoleRef</h3>
+							<h3 class="card-title text-md" v-else>Specification</h3>
+						</div>
+						<c-jsontree id="txtSpec" v-model="raw.spec" class="card-body p-2"></c-jsontree>
+					</div>
 				</div>
 			</div>
 		</div>
+		<!-- yaml tab -->
+		<div v-show="isYaml" class="card-body p-1">
+			<div class="row">
+				<div class="col-sm-12 text-right">
+					<b-button variant="primary" size="sm" @click="onApply">Apply</b-button>
+					<b-button variant="secondary" size="sm" @click="onReset">Reset</b-button>
+					<b-button variant="secondary" size="sm" @click="isYaml=false">Close</b-button>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-md-12">
+					<c-aceeditor id="txtYaml" v-model="raw" v-on:error="onError" style="min-height: calc(100vh - 85px)"></c-aceeditor>
+				</div>
+			</div>
+		</div>
+		<!-- delete overlay -->
+		<template #overlay>
+			<div v-if="deleteOverlay.processing" class="text-center">
+				<b-spinner small class="mr-2" label="please wait"></b-spinner><span>Watching DELETE status...</span>
+			</div>
+			<div v-else class="text-center">
+				<p>Are you sure DELETE it?</p>
+				<div class="text-center">
+					<b-button variant="outline-danger" size="sm" class="mr-1" @click="deleteOverlay.visible = false">Cancel</b-button>
+					<b-button variant="success" size="sm" @click="onDelete">OK</b-button>
+				</div>
+			</div>
+		</template>
+		</b-overlay>
 	</div>
-
-	<!-- Main content -->
-	<section class="content">
-	<div class="container-fluid">
-		<b-tabs content-class="col-md-12" card>
-			<!-- summary tab -->
-			<b-tab title="Summary" active>
-				<div class="row">
-					<div class="col-md-12">
-						<div class="card">
-							<div class="card-header"><h3 class="card-title">Meta data</h3></div>
-							<div class="card-body">
-								<dl class="row">
-									<dt class="col-sm-2">Annotations</dt>
-									<!-- <dt class="col-sm-2">Annotations<i class="fas fa-edit ml-2 text-secondary"></i></dt> -->
-									<dd class="col-sm-10 text-truncate">
-										<ul class="list-unstyled mb-0">
-											<li v-for="(value, name) in raw.metadata.annotations" v-bind:key="name"><span class="badge badge-secondary font-weight-light text-sm mb-1">{{ name }}:{{ value }}</span></li>
-										</ul>
-									</dd>
-									<dt class="col-sm-2">Labels</dt>
-									<!-- <dt class="col-sm-2">Labels<i class="fas fa-edit ml-2 text-secondary"></i></dt> -->
-									<dd class="col-sm-10">
-										<ul class="list-unstyled mb-0">
-											<li v-for="(value, name) in raw.metadata.labels" v-bind:key="name"><span class="badge badge-secondary font-weight-light text-sm mb-1">{{ name }}:{{ value }}</span></li>
-										</ul>
-									</dd>
-									<dt class="col-sm-2">Create at</dt><dd class="col-sm-10">{{ raw.metadata.creationTimestamp }}</dd>
-									<dt class="col-sm-2">UID</dt><dd class="col-sm-10">{{ raw.metadata.uid }}</dd>
-								</dl>
-							</div>
-						</div>
-					</div>
-				</div>
-				<div class="row" v-if="crd != 'Storage Class'">
-					<div class="col-md-12">
-						<div class="card">
-							<div class="card-header">
-								<h3 class="card-title" v-if="crd=='Config Map' || crd=='Secret'">Data</h3>
-								<h3 class="card-title" v-else-if="crd=='Service Account'">Secrets</h3>
-								<h3 class="card-title" v-else-if="crd=='Role' || crd=='Cluster Role'">Rules</h3>
-								<h3 class="card-title" v-else-if="crd=='Role Binding' || crd=='Cluster Role Binding'">Subjects,RoleRef</h3>
-								<h3 class="card-title" v-else>Specification</h3>
-							</div>
-							<c-jsontree id="txtSpec" v-model="raw.spec" class="card-body"></c-jsontree>
-							
-						</div>
-					</div>
-				</div>
-			</b-tab>
-			<!-- yaml tab -->
-			<b-tab title="Yaml">
-				<div class="row mb-2">
-					<div class="col-sm-12 text-right">
-						<b-button variant="primary" size="sm" @click="onPatch">Patch</b-button>
-						<b-button variant="secondary" size="sm" @click="onReset">Reset</b-button>
-					</div>
-				</div>
-				<div class="row">
-					<div class="col-md-12">
-						<div class="card">
-							<div class="card-header"></div>
-							<c-aceeditor id="txtYaml" class="card-body" v-model="raw" v-on:error="onError" style="min-height: calc(100vh - 210px - 60px)"></c-aceeditor>
-						</div>
-					</div>
-				</div>
-			</b-tab>
-		</b-tabs>
-	</div>
-	</section>
-	<!-- /.content -->
-</div>
-<!-- /.content-wrapper -->
+</section>
 </template>
 <script>
 
 import axios			from "axios"
 import VueAceEditor 	from "@/components/aceeditor"
 import VueJsonTree 		from "@/components/jsontree"
-import VueNavigator 	from "@/components/navigator"
-
 
 export default {
+	props:["crd", "badge", "group", "name", "url","visible"],
 	components: {
 		"c-aceeditor": { extends: VueAceEditor },
 		"c-jsontree": { extends: VueJsonTree },
-		"c-navigator": { extends: VueNavigator }
 	},
 	data() {
 		return {
-			badge: this.$route.query.crd ? this.$route.query.crd.substring(0,1): "P",
-			group: this.$route.query.group ?  this.$route.query.group: "Workload", 
-			crd : this.$route.query.crd ?  this.$route.query.crd: "pod",
-			name : this.$route.query.name ? this.$route.query.name: "httpbin",
 			origin: { metadata: {}, spec: {} },
 			raw: { metadata: {}, spec: {} },
+			isYaml: false,
 			deleteOverlay: {
 				visible : false,
 				processing : false,
 				timer: null
-			}
+			},
+			localUrl: ""
 		}
 	},
-	layout: "default",
-	created() {
-		this.$nuxt.$on("navbar-context-selected", (ctx) => this.query() );
-		if(this.currentContext()) this.$nuxt.$emit("navbar-context-selected");
-	},
-	beforeDestroy(){
-		this.$nuxt.$off('navbar-context-selected')
+	watch: {
+		url(newVal) {
+			if(newVal && (newVal != this.localUrl)) {
+				this.onSync();
+				this.localUrl = newVal;
+			}
+			
+		}
 	},
 	methods: {
 		// 조회
-		query() {
-			axios.get(`${this.backendUrl()}/raw/clusters/${this.currentContext()}/${this.$route.query.url}`)
+		onSync() {
+			axios.get(`${this.backendUrl()}/raw/clusters/${this.currentContext()}/${this.url}`)
 				.then( resp => {
 					this.origin = Object.assign({}, resp.data);
 					this.raw = resp.data;
@@ -159,7 +138,7 @@ export default {
 				})
 				.catch(e => { this.msghttp(e);});
 		},
-		onPatch() {
+		onApply() {
 			axios.put(`${this.backendUrl()}/raw/clusters/${this.currentContext()}`, this.raw)
 				.then( resp => {
 					this.origin = Object.assign({}, resp.data);
@@ -181,15 +160,17 @@ export default {
 					if (resp.status == "404") {
 						this.deleteOverlay.visible = false;
 						this.deleteOverlay.processing = false;
-						this.$router.go(-1);
+						this.$emit("delete");
+						this.$emit("close");
 					} else {
-						setTimeout(() => { this.watch(); }, 3000);
+						setTimeout(() => { this.watch(); }, 2000);
 					}
 				}).catch( error => {
 					if(error.response && error.response.status == "404") {
 						this.deleteOverlay.visible = false;
 						this.deleteOverlay.processing = false;
-						this.$router.go(-1);
+						this.$emit("delete");
+						this.$emit("close");
 					} else {
 						this.msghttp(error);
 					}


### PR DESCRIPTION
* refactoring view page 

* using on list page
```
<template v-slot:cell(name)="data">
  <a href="#" @click="sidebar={visible:true, name:data.item.name, src:`api/v1/namespaces/${data.item.namespace}/pods/${data.item.name}`}"> {{ data.value }}</a>
</template>

....

<b-sidebar v-model="sidebar.visible" width="50em" right shadow no-header>
  <c-view crd="Pod" group="Workload" :name="sidebar.name" :url="sidebar.src" @delete="query_All()" @close="sidebar.visible=false"/>
</b-sidebar>
```

```
import VueView from "@/pages/view.vue"

export default {
  components: {
    "c-view": { extends: VueView }
  },
 data() {
    return {
      sidebar: {
        visible: false,
        name: "",
        src: ""
      }
    }
},
```
