### PR TITLE
fix: Unable to retrieve the complete list of server APIs

### DIFF
--- a/src/app/backend/router/apis/context.go
+++ b/src/app/backend/router/apis/context.go
@@ -88,8 +88,10 @@ func GetContext(c *gin.Context) {
 
 		resourcesList, err := discoveryClient.ServerPreferredResources()
 		if err != nil {
-			g.SendMessage(http.StatusInternalServerError, err.Error(), err)
-			return
+			if _, resourcesList, err = discoveryClient.ServerGroupsAndResources(); err != nil {
+				g.SendMessage(http.StatusInternalServerError, err.Error(), err)
+				return
+			}
 		}
 
 		// make a "groups > group > resources > resource" data structure


### PR DESCRIPTION
ServerPreferredResources 조회 오류 시  ServerGroupsAndResources 호출하여 가능 리소스만 조회하도록 수정